### PR TITLE
fixes ssm-proxy.sh to work on ubuntu machine

### DIFF
--- a/scripts/ssm-proxy.sh
+++ b/scripts/ssm-proxy.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-#!/bin/bash
 # Configuration
 # Change these values to reflect your environment
 AWS_PROFILE='cloud9'


### PR DESCRIPTION
*Issue #, if available:*
  I haven't created any issue relating to this PR.

*Description of changes:*
  ssm-proxy.sh produces errors when connecting from ubuntu machine to cloud9 ide.
  So I put `#!/bin/bash` on the first line.

  *Error log produced before this change*
  ```bash
[14:27:16.923] Log Level: 2
[14:27:16.927] remote-ssh@0.65.7
[14:27:16.928] linux x64
[14:27:16.965] SSH Resolver called for "ssh-remote+cloud9", attempt 1
[14:27:16.965] "remote.SSH.useLocalServer": true
[14:27:16.966] "remote.SSH.path": undefined
[14:27:16.966] "remote.SSH.configFile": undefined
[14:27:16.966] "remote.SSH.useFlock": true
[14:27:16.967] "remote.SSH.lockfilesInTmp": false
[14:27:16.967] "remote.SSH.localServerDownload": auto
[14:27:16.967] "remote.SSH.remoteServerListenOnSocket": false
[14:27:16.968] "remote.SSH.showLoginTerminal": false
[14:27:16.968] "remote.SSH.defaultExtensions": []
[14:27:16.968] "remote.SSH.loglevel": 2
[14:27:16.969] SSH Resolver called for host: cloud9
[14:27:16.969] Setting up SSH remote "cloud9"
[14:27:16.976] Acquiring local install lock: /tmp/vscode-remote-ssh-cloud9-install.lock
[14:27:16.978] Looking for existing server data file at /home/smaruy30/.config/Code/User/globalStorage/ms-vscode-remote.remote-ssh/vscode-ssh-host-cloud9-379476f0e13988d90fab105c5c19e7abc8b1dea8-0.65.7/data.json
[14:27:16.978] Using commit id "379476f0e13988d90fab105c5c19e7abc8b1dea8" and quality "stable" for server
[14:27:16.984] Install and start server if needed
[14:27:16.991] PATH: `my lenghty pathes`
[14:27:16.991] Checking ssh with "ssh -V"
[14:27:17.014] > OpenSSH_8.2p1 Ubuntu-4ubuntu0.3, OpenSSL 1.1.1f  31 Mar 2020

[14:27:17.021] askpass server listening on /run/user/1000/vscode-ssh-askpass-c01d65e2181a43c1d3626c135682659db5098e33.sock
[14:27:17.022] Spawning local server with {"serverId":1,"ipcHandlePath":"/run/user/1000/vscode-ssh-askpass-510e7756dd66c407c0c166ac7ac286497079a155.sock","sshCommand":"ssh","sshArgs":["-v","-T","-D","36345","-o","ConnectTimeout=60","cloud9"],"dataFilePath":"/home/smaruy30/.config/Code/User/globalStorage/ms-vscode-remote.remote-ssh/vscode-ssh-host-cloud9-379476f0e13988d90fab105c5c19e7abc8b1dea8-0.65.7/data.json"}
[14:27:17.022] Local server env: {"DISPLAY":":0","ELECTRON_RUN_AS_NODE":"1","SSH_ASKPASS":"/home/smaruy30/.vscode/extensions/ms-vscode-remote.remote-ssh-0.65.7/out/local-server/askpass.sh","VSCODE_SSH_ASKPASS_NODE":"/usr/share/code/code","VSCODE_SSH_ASKPASS_MAIN":"/home/smaruy30/.vscode/extensions/ms-vscode-remote.remote-ssh-0.65.7/out/askpass-main.js","VSCODE_SSH_ASKPASS_HANDLE":"/run/user/1000/vscode-ssh-askpass-c01d65e2181a43c1d3626c135682659db5098e33.sock"}
[14:27:17.033] Spawned 83552
[14:27:17.269] > local-server-1> Spawned ssh, pid=83607
[14:27:17.277] stderr> OpenSSH_8.2p1 Ubuntu-4ubuntu0.3, OpenSSL 1.1.1f  31 Mar 2020
[14:27:18.748] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 19: [: Online: unexpected operator
[14:27:27.700] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:27.700] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:27:33.954] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:33.954] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:27:40.180] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:40.181] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:27:46.388] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:46.389] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:27:52.821] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:52.821] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:27:58.977] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:27:58.980] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:28:05.243] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:28:05.243] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:28:11.567] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 28: [: Online: unexpected operator
[14:28:11.568] stderr> /home/smaruy30/.ssh/ssm-proxy.sh: 35: let: not found
[14:28:17.328] stderr> Connection timed out during banner exchange
[14:28:17.329] > local-server-1> ssh child died, shutting down
[14:28:17.335] Local server exit: 0
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
