### PR TITLE
Updated CFN template to include ImageId

### DIFF
--- a/templates/cloud9instance.yml
+++ b/templates/cloud9instance.yml
@@ -17,6 +17,7 @@ Resources:
       ConnectionType: CONNECT_SSM
       Description: Cloud9 instance for use with VS Code Remote SSH
       Name: VS Code Remote SSH Demo
+      ImageId: amazonlinux-2-x86_64
 
 Outputs:
   Cloud9Instance:


### PR DESCRIPTION
The [ImageId](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloud9-environmentec2.html\#cfn-cloud9-environmentec2-imageid) is now a required property when creating a Cloud9 instance.

*Issue #, if available:*

*Description of changes:*
Updated the CloudFormation template to include the AMI alias for AmazonLinux 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
