### PR TITLE
Added option to set PATH for aws cli

### DIFF
--- a/scripts/ssm-proxy.sh
+++ b/scripts/ssm-proxy.sh
@@ -13,6 +13,9 @@ SLEEP_DURATION=5
 HOST=$1
 PORT=$2
 
+# Set aws cli path
+PATH=/usr/local/bin:$PATH
+
 STATUS=`aws ssm describe-instance-information --filters Key=InstanceIds,Values=${HOST} --output text --query 'InstanceInformationList[0].PingStatus' --profile ${AWS_PROFILE} --region ${AWS_REGION}`
 
 # If the instance is online, start the session


### PR DESCRIPTION
This script was working before until recently for my case in Mac. For some reason the aws cli path of /usr/local/bin was not set. Added this option to include it in the PATH. Other users can also custom change this where their awscli is installed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
