### PR TITLE
Add conditional expression for determining VSCode remote SSH connection.

### DIFF
--- a/scripts/stop-if-inactive.sh
+++ b/scripts/stop-if-inactive.sh
@@ -57,7 +57,8 @@ is_vfs_connected() {
 }
 
 is_vscode_connected() {
-    pgrep -u ec2-user -f .vscode-server/bin/ -a | grep -v -F 'shellIntegration-bash.sh' >/dev/null
+    pgrep -u ec2-user -f .vscode-server/bin/ -a | grep -v -F 'shellIntegration-bash.sh' >/dev/null || \
+    pgrep -u ec2-user -f /home/ec2-user/.vscode-server/code- -a >/dev/null
 }
 
 if is_shutting_down; then


### PR DESCRIPTION
[stop-in-active.sh](https://github.com/aws-samples/cloud9-to-power-vscode-blog/blob/main/scripts/stop-if-inactive.sh) is no longer working properly.
I assume this is due to [VSCode March 2024 update](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_88.md#ssh).
It changed the path of the binary file ( `/home/ec2-user/.vscode-server/bin/` ) used to determine SSH connections.

This commit fixes this problem.
I Added a conditional expression to detect `/home/ec2-user/.vscode-server/`, which is the new path of the binary file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
